### PR TITLE
fix pagination function to use kwargs for next token

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,4 +16,3 @@ repos:
     rev: v1.4.0
     hooks:
       - id: doctoc
-        language: system

--- a/README.md
+++ b/README.md
@@ -41,11 +41,14 @@ The exporter should be exposed on port `8000`
 
 ### AWS Backup
 
+* aws_backup_job_collector_success
 * aws_backup_job_size_bytes
 * aws_backup_job_percent_done
-* aws_backup_recovery_points
+* aws_backup_vault_collector_success
+* aws_backup_vault_recovery_points
 
 ### AWS SNS
 
+* sns_platform_application_collector_success
 * sns_platform_application_enabled
 * sns_platform_application_cert_expiry

--- a/aws_exporter/__main__.py
+++ b/aws_exporter/__main__.py
@@ -7,21 +7,6 @@
 #
 # THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+from aws_exporter.cli import main
 
-from aws_exporter.util import paginate
-
-
-def test_paginate():
-    def produce(NextToken=None):
-        if NextToken == 'END':
-            return dict()
-        elif NextToken == 'START':
-            return dict(NextToken='END')
-        else:
-            return dict(NextToken='START')
-
-    def observe(data):
-        if 'NextToken' in data:
-            assert data['NextToken'] in ['START', 'END']
-
-    paginate(produce, observe)
+main()

--- a/aws_exporter/backup.py
+++ b/aws_exporter/backup.py
@@ -9,15 +9,20 @@
 
 import boto3
 
-from aws_exporter.metrics import (BACKUP_JOB_PERCENT_DONE,
-                                  BACKUP_JOB_SIZE_BYTES,
-                                  BACKUP_VAULT_RECOVERY_POINTS)
-from aws_exporter.util import paginate
+from aws_exporter.metrics import (
+    BACKUP_JOB_COLLECTOR_SUCCESS,
+    BACKUP_VAULT_COLLECTOR_SUCCESS,
+    BACKUP_JOB_PERCENT_DONE,
+    BACKUP_JOB_SIZE_BYTES,
+    BACKUP_VAULT_RECOVERY_POINTS)
+
+from aws_exporter.util import paginate, success_metric
 from aws_exporter.sts import get_account_id
 
 BACKUP = boto3.client('backup')
 
 
+@success_metric(BACKUP_JOB_COLLECTOR_SUCCESS)
 def get_backup_jobs():
     """
     {
@@ -74,6 +79,7 @@ def get_backup_jobs():
     paginate(BACKUP.list_backup_jobs, observe)
 
 
+@success_metric(BACKUP_VAULT_COLLECTOR_SUCCESS)
 def get_backup_vaults():
     """
     {

--- a/aws_exporter/metrics.py
+++ b/aws_exporter/metrics.py
@@ -38,7 +38,7 @@ BACKUP_VAULT_COLLECTOR_SUCCESS = Gauge(
     'aws_backup_vault_collector_success', 'AWS Backup vault collector success', COMMON_LABELS)
 
 BACKUP_VAULT_RECOVERY_POINTS = Gauge(
-    'aws_backup_recovery_points', 'AWS Backup vault number of recovery points', BACKUP_VAULT_LABELS)
+    'aws_backup_vault_recovery_points', 'AWS Backup vault number of recovery points', BACKUP_VAULT_LABELS)
 
 ###############################################################################
 # AWS SNS push notifications

--- a/aws_exporter/metrics.py
+++ b/aws_exporter/metrics.py
@@ -24,12 +24,18 @@ BACKUP_JOB_LABELS = COMMON_LABELS + [
     'backup_vault_name',
 ]
 
+BACKUP_JOB_COLLECTOR_SUCCESS = Gauge(
+    'aws_backup_job_collector_success', 'AWS Backup job collector success', COMMON_LABELS)
+
 BACKUP_JOB_SIZE_BYTES = Gauge(
     'aws_backup_job_size_bytes', 'AWS Backup job size in bytes', BACKUP_JOB_LABELS)
 BACKUP_JOB_PERCENT_DONE = Gauge(
     'aws_backup_job_percent_done', 'AWS Backup job percent done', BACKUP_JOB_LABELS)
 
 BACKUP_VAULT_LABELS = COMMON_LABELS + ['backup_vault_name']
+
+BACKUP_VAULT_COLLECTOR_SUCCESS = Gauge(
+    'aws_backup_vault_collector_success', 'AWS Backup vault collector success', COMMON_LABELS)
 
 BACKUP_VAULT_RECOVERY_POINTS = Gauge(
     'aws_backup_recovery_points', 'AWS Backup vault number of recovery points', BACKUP_VAULT_LABELS)
@@ -40,6 +46,9 @@ BACKUP_VAULT_RECOVERY_POINTS = Gauge(
 SNS_PLATFORM_APPLICATION_LABELS = COMMON_LABELS + [
     'sns_platform_application_name'
 ]
+
+SNS_PLATFORM_APPLICATION_COLLECTOR_SUCCESS = Gauge(
+    'sns_platform_application_collector_success', 'AWS SNS platform application collector success', COMMON_LABELS)
 
 SNS_PLATFORM_APPLICATION_ENABLED = Gauge(
     'sns_platform_application_enabled', 'AWS SNS platform application enabled', SNS_PLATFORM_APPLICATION_LABELS)

--- a/aws_exporter/sns.py
+++ b/aws_exporter/sns.py
@@ -10,12 +10,17 @@
 import boto3
 import datetime
 
-from aws_exporter.metrics import (SNS_PLATFORM_APPLICATION_CERT_EXPIRY, SNS_PLATFORM_APPLICATION_ENABLED)
-from aws_exporter.util import paginate
+from aws_exporter.metrics import (
+    SNS_PLATFORM_APPLICATION_COLLECTOR_SUCCESS,
+    SNS_PLATFORM_APPLICATION_CERT_EXPIRY,
+    SNS_PLATFORM_APPLICATION_ENABLED)
+
+from aws_exporter.util import paginate, success_metric
 from aws_exporter.sts import get_account_id
 
 SNS = boto3.client('sns')
 
+@success_metric(SNS_PLATFORM_APPLICATION_COLLECTOR_SUCCESS)
 def get_platform_applications():
     """
     {

--- a/aws_exporter/sts.py
+++ b/aws_exporter/sts.py
@@ -9,8 +9,11 @@
 
 import boto3
 
+from functools import lru_cache
+
 STS = boto3.client('sts')
 
 
+@lru_cache(maxsize=None)
 def get_account_id():
     return STS.get_caller_identity()['Account']

--- a/aws_exporter/util.py
+++ b/aws_exporter/util.py
@@ -17,4 +17,4 @@ def paginate(data_function, process_function):
         if 'NextToken' not in response:
             break
 
-        response = data_function(response['NextToken'])
+        response = data_function(NextToken=response['NextToken'])

--- a/default.nix
+++ b/default.nix
@@ -1,11 +1,20 @@
 with import <nixpkgs> {};
 
-pkgs.mkShell {
-  buildInputs = [
+let
+  mach-nix = import (
+    builtins.fetchGit {
+      url = "https://github.com/DavHau/mach-nix/";
+      ref = "2.1.0";
+    }
+  );
+in
+mach-nix.mkPythonShell {
+  requirements = ''
+    wheel
+    setuptools
+    prometheus_client
+    boto3
+    tox
     pre-commit
-  ];
-
-  shellHook = ''
-    export PATH="$PATH:$HOME/.yarn/bin"
   '';
 }

--- a/default.nix
+++ b/default.nix
@@ -16,5 +16,6 @@ mach-nix.mkPythonShell {
     boto3
     tox
     pre-commit
+    nodeenv
   '';
 }


### PR DESCRIPTION
should fix kwarg issue

```
[aws-exporter-c7596f44b-w7w9t] Traceback (most recent call last):
[aws-exporter-c7596f44b-w7w9t]   File "/usr/local/bin/aws-exporter", line 11, in <module>
[aws-exporter-c7596f44b-w7w9t]     load_entry_point('aws-exporter==0.1.2.dev6+g8a78f7b', 'console_scripts', 'aws-exporter')()
[aws-exporter-c7596f44b-w7w9t]   File "/usr/local/lib/python3.8/site-packages/aws_exporter-0.1.2.dev6+g8a78f7b-py3.8.egg/aws_exporter/cli.py", line 24, in main
[aws-exporter-c7596f44b-w7w9t]     get_backup_jobs()
[aws-exporter-c7596f44b-w7w9t]   File "/usr/local/lib/python3.8/site-packages/aws_exporter-0.1.2.dev6+g8a78f7b-py3.8.egg/aws_exporter/backup.py", line 74, in get_backup_jobs
[aws-exporter-c7596f44b-w7w9t]     paginate(BACKUP.list_backup_jobs, observe)
[aws-exporter-c7596f44b-w7w9t]   File "/usr/local/lib/python3.8/site-packages/aws_exporter-0.1.2.dev6+g8a78f7b-py3.8.egg/aws_exporter/util.py", line 20, in paginate
[aws-exporter-c7596f44b-w7w9t]     response = data_function(response['NextToken'])
[aws-exporter-c7596f44b-w7w9t]   File "/usr/local/lib/python3.8/site-packages/botocore-1.17.11-py3.8.egg/botocore/client.py", line 313, in _api_call
[aws-exporter-c7596f44b-w7w9t]     raise TypeError(
[aws-exporter-c7596f44b-w7w9t] TypeError: list_backup_jobs() only accepts keyword arguments.
```

additionally added general success metrics for jobs and catching exceptions in collector functions