### PR TITLE
Filter backup jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@
 *.egg-info
 
 .tox
+.direnv
+.mypy_cache
 .eggs
 __pycache__

--- a/default.nix
+++ b/default.nix
@@ -1,25 +1,5 @@
 with import <nixpkgs> {};
 
-# let
-#   mach-nix = import (
-#     builtins.fetchGit {
-#       url = "https://github.com/DavHau/mach-nix/";
-#       ref = "2.1.0";
-#     }
-#   );
-# in
-# mach-nix.mkPythonShell {
-#   requirements = ''
-#     wheel
-#     setuptools
-#     prometheus_client
-#     boto3
-#     tox
-#     pre-commit
-#     nodeenv
-#   '';
-# }
-
 let
   aws_exporter = with python3.pkgs; buildPythonApplication rec {
     pname = "aws_exporter";

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.setuptools_scm]
+
+[tool.black]
+line-length = 160

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,3 +31,6 @@ exclude =
 [isort]
 known_first_party =
   aws-exporter
+
+[flake8]
+max-line-length = 160


### PR DESCRIPTION
AWS pretty much doesn't seem to retire backup jobs in their API, which makes it very difficult to alert on failure.

This change should drop them after 1 day.

note: also includes some formatting changes, relevant changes are here: 
* https://github.com/ClarkSource/aws-exporter/pull/8/files#diff-04b900db6a7237fc05edd5b86f8c618aR77
* https://github.com/ClarkSource/aws-exporter/pull/8/files#diff-ff8b781c8874b2aeb9cad6bce4f12de9R19