### PR TITLE
feat(ec2): instance creation metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Prometheus exporter for generic AWS metrics.
   - [AWS SNS](#aws-sns)
   - [AWS EC2 AMIs](#aws-ec2-amis)
     - [configuration](#configuration)
+  - [AWS EC2 Instances](#aws-ec2-instances)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -67,3 +68,8 @@ The exporter should be exposed on port `8000`
 #### configuration
 
 `AWS_EXPORTER_EC2_AMI_OWNERS` - additional AMI owners, comma separated.
+
+### AWS EC2 Instances
+
+* ec2_instance_collector_success
+* ec2_instance_creation_date

--- a/aws_exporter/aws/backup.py
+++ b/aws_exporter/aws/backup.py
@@ -8,6 +8,7 @@
 # THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 import datetime
+import logging
 
 import boto3
 from aws_exporter.metrics import (BACKUP_JOB_COLLECTOR_SUCCESS,
@@ -19,6 +20,7 @@ from aws_exporter.aws.sts import get_account_id
 from aws_exporter.util import paginate, success_metric
 
 BACKUP = boto3.client("backup")
+LOGGER = logging.getLogger(__name__)
 
 
 @success_metric(BACKUP_JOB_COLLECTOR_SUCCESS)
@@ -73,9 +75,13 @@ def get_backup_jobs():
             if "BackupSizeInBytes" in job:
                 BACKUP_JOB_SIZE_BYTES.labels(*labels).set(float(job["BackupSizeInBytes"]))
 
+    LOGGER.debug('querying Backup jobs')
+
     paginate(
         BACKUP.list_backup_jobs, observe, dict(ByCreatedAfter=datetime.datetime.now() - datetime.timedelta(1)),
     )
+
+    LOGGER.debug('finished querying Backup jobs')
 
 
 @success_metric(BACKUP_VAULT_COLLECTOR_SUCCESS)
@@ -105,4 +111,8 @@ def get_backup_vaults():
 
             BACKUP_VAULT_RECOVERY_POINTS.labels(*labels).set(vault["NumberOfRecoveryPoints"])
 
+    LOGGER.debug('querying Backup vaults')
+
     paginate(BACKUP.list_backup_vaults, observe)
+
+    LOGGER.debug('finished querying Backup vaults')

--- a/aws_exporter/aws/ec2.py
+++ b/aws_exporter/aws/ec2.py
@@ -12,37 +12,70 @@ import boto3
 import time
 import logging
 
-from aws_exporter.metrics import (EC2_AMI_COLLECTOR_SUCCESS, EC2_AMI_CREATION_DATE)
+from aws_exporter.metrics import EC2_AMI_COLLECTOR_SUCCESS, EC2_AMI_CREATION_DATE, EC2_INSTANCE_COLLECTOR_SUCCESS, EC2_INSTANCE_CREATION_DATE
 from aws_exporter.util import paginate, success_metric
 from aws_exporter.aws.sts import get_account_id
 
-EC2 = boto3.client('ec2')
+EC2 = boto3.client("ec2")
 LOGGER = logging.getLogger(__name__)
 
 
 @success_metric(EC2_AMI_COLLECTOR_SUCCESS)
 def get_amis(ami_owners):
     def observe(response):
-        for image in response.get('Images', []):
+        for image in response.get("Images", []):
             labels = [
                 get_account_id(),
-                image['Architecture'],
-                image['EnaSupport'],
-                image['Hypervisor'],
-                image['ImageId'],
-                image['Name'],
-                image['OwnerId'],
-                image['PlatformDetails'],
-                image['Public'],
-                image['RootDeviceName'],
-                image['RootDeviceType'],
-                image['VirtualizationType'],
+                image["ImageId"],
+                image["Architecture"],
+                image["EnaSupport"],
+                image["Hypervisor"],
+                image["Name"],
+                image["OwnerId"],
+                image["PlatformDetails"],
+                image["Public"],
+                image["RootDeviceName"],
+                image["RootDeviceType"],
+                image["VirtualizationType"],
             ]
 
-            creation_date = time.strptime(image['CreationDate'], '%Y-%m-%dT%H:%M:%S.%fZ')
+            creation_date = time.strptime(image["CreationDate"], "%Y-%m-%dT%H:%M:%S.%fZ")
 
             EC2_AMI_CREATION_DATE.labels(*labels).set(time.mktime(creation_date))
 
     paginate(EC2.describe_images, observe, dict(Owners=ami_owners))
+
+
+@success_metric(EC2_INSTANCE_COLLECTOR_SUCCESS)
+def get_instances():
+    def observe(response):
+        for reservation in response.get("Reservations", []):
+            for instance in reservation.get('Instances', []):
+                metadata_options = instance['MetadataOptions']
+
+                labels = [
+                    get_account_id(),
+                    instance['ImageId'],
+                    instance['InstanceId'],
+                    instance['InstanceType'],
+                    instance['Architecture'],
+                    instance['EbsOptimized'],
+                    instance['EnaSupport'],
+                    instance['Hypervisor'],
+                    instance['RootDeviceName'],
+                    instance['RootDeviceType'],
+                    instance['SourceDestCheck'],
+                    instance['VirtualizationType'],
+                    metadata_options['HttpTokens'],
+                    metadata_options['HttpPutResponseHopLimit'],
+                    metadata_options['HttpEndpoint'],
+                ]
+
+                launch_time = instance['LaunchTime']
+
+                EC2_INSTANCE_CREATION_DATE.labels(*labels).set(time.mktime(launch_time.timetuple()))
+
+    paginate(EC2.describe_instances, observe)
+
 
 # -*- coding: utf-8 -*-

--- a/aws_exporter/aws/ec2.py
+++ b/aws_exporter/aws/ec2.py
@@ -26,24 +26,28 @@ def get_amis(ami_owners):
         for image in response.get("Images", []):
             labels = [
                 get_account_id(),
-                image["ImageId"],
-                image["Architecture"],
-                image["EnaSupport"],
-                image["Hypervisor"],
-                image["Name"],
-                image["OwnerId"],
-                image["PlatformDetails"],
-                image["Public"],
-                image["RootDeviceName"],
-                image["RootDeviceType"],
-                image["VirtualizationType"],
+                image.get("ImageId"),
+                image.get("Architecture"),
+                image.get("EnaSupport"),
+                image.get("Hypervisor"),
+                image.get("Name"),
+                image.get("OwnerId"),
+                image.get("PlatformDetails"),
+                image.get("Public"),
+                image.get("RootDeviceName"),
+                image.get("RootDeviceType"),
+                image.get("VirtualizationType"),
             ]
 
             creation_date = time.strptime(image["CreationDate"], "%Y-%m-%dT%H:%M:%S.%fZ")
 
             EC2_AMI_CREATION_DATE.labels(*labels).set(time.mktime(creation_date))
 
+    LOGGER.debug('querying EC2 AMIs')
+
     paginate(EC2.describe_images, observe, dict(Owners=ami_owners))
+
+    LOGGER.debug('finished querying EC2 AMIs')
 
 
 @success_metric(EC2_INSTANCE_COLLECTOR_SUCCESS)
@@ -55,27 +59,31 @@ def get_instances():
 
                 labels = [
                     get_account_id(),
-                    instance['ImageId'],
-                    instance['InstanceId'],
-                    instance['InstanceType'],
-                    instance['Architecture'],
-                    instance['EbsOptimized'],
-                    instance['EnaSupport'],
-                    instance['Hypervisor'],
-                    instance['RootDeviceName'],
-                    instance['RootDeviceType'],
-                    instance['SourceDestCheck'],
-                    instance['VirtualizationType'],
-                    metadata_options['HttpTokens'],
-                    metadata_options['HttpPutResponseHopLimit'],
-                    metadata_options['HttpEndpoint'],
+                    instance.get('ImageId'),
+                    instance.get('InstanceId'),
+                    instance.get('InstanceType'),
+                    instance.get('Architecture'),
+                    instance.get('EbsOptimized'),
+                    instance.get('EnaSupport'),
+                    instance.get('Hypervisor'),
+                    instance.get('RootDeviceName'),
+                    instance.get('RootDeviceType'),
+                    instance.get('SourceDestCheck'),
+                    instance.get('VirtualizationType'),
+                    metadata_options.get('HttpTokens'),
+                    metadata_options.get('HttpPutResponseHopLimit'),
+                    metadata_options.get('HttpEndpoint'),
                 ]
 
                 launch_time = instance['LaunchTime']
 
                 EC2_INSTANCE_CREATION_DATE.labels(*labels).set(time.mktime(launch_time.timetuple()))
 
+    LOGGER.debug('querying EC2 instances')
+
     paginate(EC2.describe_instances, observe)
+
+    LOGGER.debug('finished querying EC2 instances')
 
 
 # -*- coding: utf-8 -*-

--- a/aws_exporter/aws/sns.py
+++ b/aws_exporter/aws/sns.py
@@ -9,6 +9,7 @@
 
 import boto3
 import datetime
+import logging
 
 from aws_exporter.metrics import (
     SNS_PLATFORM_APPLICATION_COLLECTOR_SUCCESS,
@@ -19,6 +20,8 @@ from aws_exporter.util import paginate, success_metric
 from aws_exporter.aws.sts import get_account_id
 
 SNS = boto3.client('sns')
+LOGGER = logging.getLogger(__name__)
+
 
 @success_metric(SNS_PLATFORM_APPLICATION_COLLECTOR_SUCCESS)
 def get_platform_applications():
@@ -80,6 +83,9 @@ def get_platform_applications():
 
                 SNS_PLATFORM_APPLICATION_CERT_EXPIRY.labels(*labels).set(expiry.timestamp())
 
+    LOGGER.debug('querying SNS platform applications')
+
     paginate(SNS.list_platform_applications, observe)
 
+    LOGGER.debug('finished querying SNS platform applications')
 

--- a/aws_exporter/cli.py
+++ b/aws_exporter/cli.py
@@ -21,6 +21,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def main():
+    delay = int(os.environ.get('AWS_EXPORTER_POLL_DELAY', 10))
     port = int(os.environ.get('AWS_EXPORTER_PORT', 8000))
     log_level = getattr(logging, os.environ.get('AWS_EXPORTER_LOG_LEVEL', 'info').upper())
 
@@ -42,12 +43,16 @@ def main():
         start_http_server(port)
 
         while True:
+            LOGGER.debug('querying resources')
+
             get_backup_vaults()
             get_backup_jobs()
             get_platform_applications()
             get_amis(ami_owners)
             get_instances()
 
-            time.sleep(10)
+            LOGGER.debug('sleeping %d seconds', delay)
+
+            time.sleep(delay)
     except KeyboardInterrupt:
         exit(137)

--- a/aws_exporter/cli.py
+++ b/aws_exporter/cli.py
@@ -15,7 +15,7 @@ from prometheus_client import start_http_server
 
 from aws_exporter.aws.backup import get_backup_jobs, get_backup_vaults
 from aws_exporter.aws.sns import get_platform_applications
-from aws_exporter.aws.ec2 import get_amis
+from aws_exporter.aws.ec2 import get_amis, get_instances
 
 LOGGER = logging.getLogger(__name__)
 
@@ -46,6 +46,7 @@ def main():
             get_backup_jobs()
             get_platform_applications()
             get_amis(ami_owners)
+            get_instances()
 
             time.sleep(10)
     except KeyboardInterrupt:

--- a/aws_exporter/metrics.py
+++ b/aws_exporter/metrics.py
@@ -61,17 +61,17 @@ SNS_PLATFORM_APPLICATION_CERT_EXPIRY = Gauge(
 # AWS EC2 AMIs
 
 EC2_AMI_LABELS = COMMON_LABELS + [
-    'architecture',
-    'ena_support',
-    'hypervisor',
-    'image_id',
-    'image_name',
-    'owner_id',
-    'platform',
-    'public',
-    'root_device_name',
-    'root_device_type',
-    'virtualization_type',
+    'ec2_ami',
+    'ec2_architecture',
+    'ec2_ena_support',
+    'ec2_hypervisor',
+    'ec2_image_name',
+    'ec2_owner_id',
+    'ec2_platform',
+    'ec2_public',
+    'ec2_root_device_name',
+    'ec2_root_device_type',
+    'ec2_virtualization_type',
 ]
 
 EC2_AMI_COLLECTOR_SUCCESS = Gauge(
@@ -79,3 +79,29 @@ EC2_AMI_COLLECTOR_SUCCESS = Gauge(
 
 EC2_AMI_CREATION_DATE = Gauge(
     'ec2_ami_creation_date', 'AWS EC2 AMI creation date in unix epoch', EC2_AMI_LABELS)
+
+###############################################################################
+# AWS EC2 Instances
+
+EC2_INSTANCE_LABELS = COMMON_LABELS + [
+    'ec2_ami',
+    'ec2_instance_id',
+    'ec2_instance_type',
+    'ec2_architecture',
+    'ec2_ebs_optimized',
+    'ec2_ena_support',
+    'ec2_hypervisor',
+    'ec2_root_device_name',
+    'ec2_root_device_type',
+    'ec2_source_dest_check',
+    'ec2_virtualization_type',
+    'ec2_metadata_options_http_tokens',
+    'ec2_metadata_options_http_put_response_hop_limit',
+    'ec2_metadata_options_endpoint',
+]
+
+EC2_INSTANCE_COLLECTOR_SUCCESS = Gauge(
+    'ec2_instance_collector_success', 'AWS EC2 instance collector success', COMMON_LABELS)
+
+EC2_INSTANCE_CREATION_DATE = Gauge(
+    'ec2_instance_creation_date', 'AWS EC2 instance creation date in unix epoch', EC2_INSTANCE_LABELS)


### PR DESCRIPTION
* introduce new metrics `ec2_instance_collector_success`. `ec2_instance_creation_date`
* standardize ec2 labels to prefix `ec2_` and rename `image_id` to `ec2_ami` - this should work better with ec2 discovery in prometheus
